### PR TITLE
fix: Serve PWA files directly from Flask

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,14 @@ INSTAGRAM_SESSION_ID = os.environ.get('INSTAGRAM_SESSION_ID')
 if not os.path.exists(DOWNLOAD_FOLDER):
     os.makedirs(DOWNLOAD_FOLDER)
 
+@app.route('/sw.js')
+def serve_sw():
+    return send_from_directory('.', 'sw.js')
+
+@app.route('/manifest.json')
+def serve_manifest():
+    return send_from_directory('.', 'manifest.json')
+
 @app.route('/')
 def index():
     return render_template('index.html')


### PR DESCRIPTION
- Added two new routes to `main.py` to explicitly serve `manifest.json` and `sw.js` from the root directory.
- This fixes an issue where the browser could not access these files, preventing the PWA from being installable on Chrome and other browsers.